### PR TITLE
Fix upstream macro conflict for clean build against v0.6 bleeding edge

### DIFF
--- a/src/Seq-G1.cpp
+++ b/src/Seq-G1.cpp
@@ -171,7 +171,7 @@ struct GtxModule : Module {
 			}
 		}
 
-		std::ostream &debug(std::ostream &os) const
+		std::ostream &logDebug(std::ostream &os) const
 		{
 			os << static_cast<int>(mode) << " " << static_cast<int>(note) << " " << static_cast<int>(octave) << " " << value;
 

--- a/src/Seq-G2.cpp
+++ b/src/Seq-G2.cpp
@@ -187,7 +187,7 @@ struct GtxModule : Module {
 			}
 		}
 
-		std::ostream &debug(std::ostream &os) const
+		std::ostream &logDebug(std::ostream &os) const
 		{
 			os << static_cast<int>(mode) << " " << static_cast<int>(note) << " " << static_cast<int>(octave) << " " << value;
 


### PR DESCRIPTION
These debug methods cause the build to fail because upstream there is a macro called 'debug' defined now. This actually broke a couple of other plugins too annoyingly. Just changing the method names resolves it.